### PR TITLE
Feat: Add `ignore_pattern` option

### DIFF
--- a/autoload/pear_tree.vim
+++ b/autoload/pear_tree.vim
@@ -12,6 +12,7 @@ let s:pear_tree_default_rules = {
             \ 'closer': '',
             \ 'not_in': [],
             \ 'not_if': [],
+            \ 'ignore_pattern': '',
             \ 'until': '[[:punct:][:space:]]'
             \ }
 
@@ -95,6 +96,10 @@ function! pear_tree#GenerateCloser(opener, wildcard, position) abort
         return ''
     endif
     if index(pear_tree#GetRule(a:opener, 'not_if'), l:trimmed_wildcard) > -1
+        return ''
+    endif
+    let l:ignore_pattern = pear_tree#GetRule(a:opener, 'ignore_pattern')
+    if l:ignore_pattern !=# '' && match(a:wildcard, l:ignore_pattern) > -1
         return ''
     endif
     " Replace unescaped * chars with the wildcard string.

--- a/autoload/pear_tree.vim
+++ b/autoload/pear_tree.vim
@@ -12,7 +12,7 @@ let s:pear_tree_default_rules = {
             \ 'closer': '',
             \ 'not_in': [],
             \ 'not_if': [],
-            \ 'ignore_pattern': '',
+            \ 'not_like': '',
             \ 'until': '[[:punct:][:space:]]'
             \ }
 
@@ -98,8 +98,8 @@ function! pear_tree#GenerateCloser(opener, wildcard, position) abort
     if index(pear_tree#GetRule(a:opener, 'not_if'), l:trimmed_wildcard) > -1
         return ''
     endif
-    let l:ignore_pattern = pear_tree#GetRule(a:opener, 'ignore_pattern')
-    if l:ignore_pattern !=# '' && match(a:wildcard, l:ignore_pattern) > -1
+    let l:not_like = pear_tree#GetRule(a:opener, 'not_like')
+    if l:not_like !=# '' && match(a:wildcard, l:not_like) > -1
         return ''
     endif
     " Replace unescaped * chars with the wildcard string.

--- a/doc/pear-tree.txt
+++ b/doc/pear-tree.txt
@@ -103,6 +103,15 @@ behavior.
               that wildcard is contained in the list.
     Example: `'<*>': {'closer': '</*>', 'not_if': ['br', 'meta']}`
 
+    not_like ~
+    Form: `'not_like': regexp`
+    Function: Do not match an opener that contains a wildcard if the value of
+              that wildcard matches the regexp pattern. See |pattern| for
+              valid patterns.
+    Example: `'<*>': {'closer': '</*>', 'not_like': '/$'}`
+             Typing `<img />` does not yield `<img /></img>` because the `/`
+             in the opener matches the regexp pattern `'/$'`.
+
     until ~
     Form: `'until': regexp`
     Function: Replace the wildcard character in the closer with the wildcard


### PR DESCRIPTION
`ignore_pattern` option enables more control over auto-closing condition.

e.g.
`let g:pear_tree_pairs = { '<*>': {'closer': '</*>', 'ignore_pattern': '/$'} }`
enables not to close self closing tags such as `<img />`, `<br />`, etc.

---

This closes #13 
Feel free to request me changes 😄 