### PR TITLE
feat: Add HTML tag closing by default for jsx/javascript

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -13,7 +13,13 @@ set cpoptions&vim
 
 let b:pear_tree_pairs = extend(deepcopy(g:pear_tree_pairs), {
             \ '`': {'closer': '`'},
-            \ '/\*\*': {'closer': '\*/'}
+            \ '/\*\*': {'closer': '\*/'},
+            \ '<*>': {'closer': '</*>',
+            \         'not_if': ['br', 'hr', 'img', 'input', 'link', 'meta',
+            \                    'area', 'base', 'col', 'command', 'embed',
+            \                    'keygen', 'param', 'source', 'track', 'wbr'],
+            \         'not_like': '/$'
+            \        }
             \ }, 'keep')
 
 let &cpoptions = s:save_cpo


### PR DESCRIPTION
Hi,

Because of the recent merge of #14 I thought that javascript was supported as well, but since we use ftdetect this had to be copied over from the `ftdetect/html.vim` to `ftdetect/javascript.vim`, which is what I did in this pull request. Currently, HTML tags are not closed at all in javascript/jsx files.

I made this a core thing, because these days javascript is such a hype along with JSX that it is almost considered "weird" if we don't support HTML tag closing in JSX. I work in JSX as well at work most of my time and this is a must for a lot of javascript developers. People would expect this to be a default these days (including myself), when installing an auto-closing plugin.

Since JSX syntax is supported for `*.jsx` and `*.js` files I put the code in `ftdetect/javascript.vim` to support both out of the box.