### PR TITLE
Add ftplugin for Rust

### DIFF
--- a/after/ftplugin/rust.vim
+++ b/after/ftplugin/rust.vim
@@ -1,0 +1,29 @@
+" Pear Tree - A painless, powerful Vim auto-pair plugin
+" Maintainer: Thomas Savage <thomasesavage@gmail.com>
+" Version: 0.8
+" License: MIT
+" Website: https://github.com/tmsvg/pear-tree
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let b:undo_ftplugin .= ' | unlet! b:pear_tree_pairs'
+
+" Rust prefixes lifetime variables and loop labels with a single quote which
+" should not be automatically closed. The 'not_at' patterns for the single quote
+" pair here prevent inserting a closing quote if the text before the cursor is
+" an opening angle bracket with zero or more following lifetime paramaters, or
+" if the character immediately before the cursor is an ampersand.
+let b:pear_tree_pairs = extend(deepcopy(g:pear_tree_pairs), {
+            \ "'": {'closer': "'", 'not_at': [
+                        \ '\w',
+                        \ '<\s*\(''\s*[a-z]\s*,\s*\)*',
+                        \ '&'
+                        \ ]},
+            \ '`': {'closer': '`'},
+            \ "```": {'closer': "```"},
+            \ '/\*': {'closer': '\*/'},
+            \ }, 'force')
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/after/ftplugin/rust.vim
+++ b/after/ftplugin/rust.vim
@@ -7,23 +7,26 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let b:undo_ftplugin .= ' | unlet! b:pear_tree_pairs'
+if exists('b:undo_ftplugin')
+    let b:undo_ftplugin .= ' | unlet! b:pear_tree_pairs'
+else
+    let b:undo_ftplugin = 'unlet! b:pear_tree_pairs'
+endif
+
+let b:pear_tree_pairs = extend(deepcopy(g:pear_tree_pairs), {
+            \ "```": {'closer': "```"},
+            \ }, 'keep')
 
 " Rust prefixes lifetime variables and loop labels with a single quote which
 " should not be automatically closed. The 'not_at' patterns for the single quote
 " pair here prevent inserting a closing quote if the text before the cursor is
 " an opening angle bracket with zero or more following lifetime paramaters, or
 " if the character immediately before the cursor is an ampersand.
-let b:pear_tree_pairs = extend(deepcopy(g:pear_tree_pairs), {
-            \ "'": {'closer': "'", 'not_at': [
-                        \ '\w',
-                        \ '<\s*\(''\s*[a-z]\s*,\s*\)*',
-                        \ '&'
-                        \ ]},
-            \ '`': {'closer': '`'},
-            \ "```": {'closer': "```"},
-            \ '/\*': {'closer': '\*/'},
-            \ }, 'force')
+let s:patterns = ['<\s*\(''\s*[a-z]\s*,\s*\)*',
+                \ '&']
+if has_key(b:pear_tree_pairs, '''')
+    let b:pear_tree_pairs['''']['not_at'] = get(b:pear_tree_pairs[''''], 'not_at', []) + s:patterns
+endif
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Thanks for this nifty plugin!

Rust benefits from special handling for single quotes. Lifetime variables are prefixed with a quote which should not be automatically closed. This PR adds an ftplugin with the appropriate configuration. I have been using the same regular expressions with vim-smartinput for a while, and they work well in my day-to-day use.