### PR TITLE
[tex] check if b:undo_ftplugin exists and otherwise set it to an empty string

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -8,6 +8,7 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+if !exists("b:undo_ftplugin") | let b:undo_ftplugin = '' | endif
 let b:undo_ftplugin .= ' | unlet! b:pear_tree_pairs'
 
 let b:pear_tree_pairs = extend(deepcopy(g:pear_tree_pairs), {


### PR DESCRIPTION
If `b:undo_ftplugin` does not exist when loading, the plugin will crash.
This change will first check if that variable already exists and otherwise set it to an empty string.